### PR TITLE
Inject $parse so that options are correctly loaded.

### DIFF
--- a/src/ng-switchery.js
+++ b/src/ng-switchery.js
@@ -5,7 +5,7 @@
  * @TODO implement Switchery as a service, https://github.com/abpetkov/switchery/pull/11
  */
 angular.module('NgSwitchery', [])
-    .directive('uiSwitch', ['$window', '$timeout','$log', function($window, $timeout, $log) {
+    .directive('uiSwitch', ['$window', '$timeout','$log', '$parse', function($window, $timeout, $log, $parse) {
 
         /**
          * Initializes the HTML element as a Switchery switch.


### PR DESCRIPTION
$parse isn't being injected, so angular is hitting the catch block and not honoring settings.
