### PR TITLE
Respond to ngDisabled directive on the ui-switch element.

### DIFF
--- a/src/ng-switchery.js
+++ b/src/ng-switchery.js
@@ -40,7 +40,7 @@ angular.module('NgSwitchery', [])
               $timeout(function() {
                 // Remove any old switcher
                 if (switcher) {
-                  switcher.switcher.remove();
+                  angular.element(switcher.switcher).remove();
                 }
                 // (re)create switcher to reflect latest state of the checkbox element
                 switcher = new $window.Switchery(elem[0], options);


### PR DESCRIPTION
It appears that Switchery doesn't respond to checkboxes being disabled after initialization (https://github.com/abpetkov/switchery/issues/30).

This update allows us to remove and re-initialize a Switchery when its checkbox is disabled/re-enabled through the magic of Angular.
