### PR TITLE
Updated Switchery package to ~0.8.1 and streamlined disabled attribute management

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Setting Options
 <input type="checkbox" class="js-switch" ui-switch="{color: '#E43B11', secondaryColor: '#F89279'}" />
 ```
 
+Disable switch
+```html
+<input type="checkbox" class="js-switch" ui-switch ng-disabled="isDisabled" />
+```
+
 
 Bower install
 ```

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-switchery",
-  "version": "1.0.0-alpha7",
+  "version": "1.0.0-alpha8",
   "main": "src/ng-switchery.js",
   "license": "MIT",
   "ignore": [
@@ -10,7 +10,7 @@
     "examples"
   ],
   "dependencies": {
-    "switchery": "~0.6.2"
+    "switchery": "~0.8.1"
   },
   "devDependencies": {
     "angular": "~1.2.19"

--- a/src/ng-switchery.js
+++ b/src/ng-switchery.js
@@ -24,13 +24,20 @@ angular.module('NgSwitchery', [])
                 options = $parse(attrs.uiSwitch)(scope);
             }
             catch (e) {}
+
             var switcher;
 
             attrs.$observe('disabled', function(value) {
-              if (value && value === 'true')
+              if (!switcher) {
+                return;
+              }
+
+              if (value) {
                 switcher.disable();
-              else
+              }
+              else {
                 switcher.enable();
+              }
             });
 
             function initializeSwitch() {
@@ -43,6 +50,10 @@ angular.module('NgSwitchery', [])
                 switcher = new $window.Switchery(elem[0], options);
                 var element = switcher.element;
                 element.checked = scope.initValue;
+                if (attrs.disabled) {
+                  switcher.disable();
+                }
+
                 switcher.setPosition(false);
                 element.addEventListener('change',function(evt) {
                     scope.$apply(function() {

--- a/src/ng-switchery.js
+++ b/src/ng-switchery.js
@@ -15,7 +15,7 @@ angular.module('NgSwitchery', [])
          * @param scope
          * @param elem
          * @param attrs
-		 * @param ngModel
+         * @param ngModel
          */
         function linkSwitchery(scope, elem, attrs, ngModel) {
             if(!ngModel) return false;
@@ -25,15 +25,12 @@ angular.module('NgSwitchery', [])
             }
             catch (e) {}
             var switcher;
-            var previousDisabledValue;
-            // Watch for attribute changes to recreate the switch if the 'disabled' attribute changes
+
             attrs.$observe('disabled', function(value) {
-              if (value == undefined || value == previousDisabledValue) {
-                return;
-              } else {
-                previousDisabledValue = value;
-              }
-              initializeSwitch();
+              if (value)
+                switcher.disable();
+              else
+                switcher.enable();
             });
 
             function initializeSwitch() {

--- a/src/ng-switchery.js
+++ b/src/ng-switchery.js
@@ -27,7 +27,7 @@ angular.module('NgSwitchery', [])
             var switcher;
 
             attrs.$observe('disabled', function(value) {
-              if (value)
+              if (value && value === 'true')
                 switcher.disable();
               else
                 switcher.enable();
@@ -57,7 +57,9 @@ angular.module('NgSwitchery', [])
         return {
             require: 'ngModel',
             restrict: 'AE',
-            scope : {initValue : '=ngModel'},
+            scope : {
+              initValue : '=ngModel'
+            },
             link: linkSwitchery
         }
     }]);


### PR DESCRIPTION
Hi,

We are using ng-switchery at Melberries, and we needed the latest features.
As such, here are the changes : 
* Updated Switchery to ~0.8.1
* Removed hacky `disabled` attribute implementation. Now have to use `ng-disabled` and it works alright without re-creating the DOM nodes (that resulted in layout trashing)

Have a great day,
Mathieu / Software Engineer
Team Melberries.