### PR TITLE
bugfix and new attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Disable switch
 <input type="checkbox" class="js-switch" ui-switch ng-disabled="isDisabled" />
 ```
 
+##Changing model values##
+By default, values passed to your ng-model will be `true` and `false`.
+If you want to change this behavior you can add `ui-switch-true-value` and `ui-switch-false-value` attributes to your input element.
+```html
+<input type="checkbox" class="js-switch" ng-model="myModel" ui-switch ui-switch-true-value="1" ui-switch-false-value="0" />
+```
 
 Bower install
 ```


### PR DESCRIPTION
Two things in this pull request:

1. I've added `ui-switch-true-value` and `ui-switch-false-value` attrs, see readme for description, i've updated it.

2. You had

```
    scope.$watch(function () {
        return ngModel.$modelValue;
    }, function(newValue,oldValue) {
        initializeSwitch()
    });
```

in link function. And then at the bottom again you had `initializeSwitch();` one more time. This caused init function to be called every time switchery is toggled from the interface. Which caused 
```
              element.addEventListener('change',function(evt) {
                    scope.$apply(function() {
                        ngModel.$setViewValue(element.checked);
                    })
```
To be added every time switchery is toggled. So you'd end up calling ngModel.$setViewValue dozens of times on every change for a single instance. 